### PR TITLE
Setup uv caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,9 @@ RUN /root/terminal-config/ensure-user-terminal-config.sh && \
 # Install uv using the official image
 # See https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
 COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
+
+# We recommend mounting in a cache for uv, so silence warnings about it being on a different volume
+# and cache python interpreter downloads in the same directory
+# https://docs.astral.sh/uv/guides/integration/docker/#caching
+ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_CACHE_DIR=/root/.cache/uv/python


### PR DESCRIPTION
- Puts python interpreter downloads in the cache
- Sets uv to copy rather than hardlink to avoid warnings

https://docs.astral.sh/uv/guides/integration/docker/#caching