### PR TITLE
feat: track ubuntu 26.04 (resolute) on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=latest
-            type=raw,value=noble
+            type=raw,value=resolute
+            type=raw,value=26.04
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
-FROM ubuntu:noble-20260410
+FROM ubuntu:resolute-20260413
 
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && \

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "baseBranches": [
+    "main",
+    "noble"
+  ],
+  "packageRules": [
+    {
+      "matchBaseBranches": ["main"],
+      "matchDepNames": ["ubuntu"],
+      "allowedVersions": "/^resolute(-.*)?$/"
+    },
+    {
+      "matchBaseBranches": ["noble"],
+      "matchDepNames": ["ubuntu"],
+      "allowedVersions": "/^noble(-.*)?$/"
+    }
   ]
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                           
  - Bump base image to ubuntu:resolute-20260413                                                                                                                        
  - Publish images tagged latest, resolute, 26.04, and tag name from main
  - Configure Renovate baseBranches so main receives only resolute-* updates and the new noble branch receives only noble-* updates                                    
                                                                                                                                                                       
  The companion noble branch contains the CI changes that publish noble + 24.04 image tags from that branch.                                                           
                                                                                                                                                                       