### PR TITLE
ci(noble): stop noble releases from tagging latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=noble


### PR DESCRIPTION
## Root cause

The `merge` job's "Create tags for publishing image" step uses `docker/metadata-action` with no `flavor:` input, so it falls back to the action default `flavor: latest=auto`. Because the tag list includes `type=ref,event=tag` and `noble-*` release tags (e.g. `noble-20260610`) are not pre-release semver, `latest=auto` auto-generates a `latest` tag on every noble tag push. That overwrites `latest` in GHCR to point at the Ubuntu 24.04 (noble) image, even though only the resolute (Ubuntu 26.04, `main`) release should own `latest`.

## Fix

Add `flavor: latest=false` to the metadata-action step to disable the automatic `latest` tagging. The existing explicit `tags:` list (`noble`, `24.04`, and the ref tag) is unchanged — noble releases still get tagged correctly, they just no longer also steal `latest`.

## Follow-up (not done in this PR)

Live `latest` in GHCR still points at the noble image from today's release; it will self-correct on the next resolute (main) release, or an admin can re-point it manually. This PR only stops future noble releases from stealing it.

## Companion PR

A matching PR targeting `main` adds the same `flavor: latest=false` there too, so `latest` becomes explicit-only (produced solely by the `type=raw,value=latest` entry that tracks resolute releases) and is immune to auto-tagging regardless of which branch releases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY3Gv2rbRV3RqePVXTCbRq)_