### PR TITLE
ci(main): make latest explicit-only, immune to auto-tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=latest


### PR DESCRIPTION
## Root cause

The `merge` job's "Create tags for publishing image" step uses `docker/metadata-action` with no `flavor:` input, so it falls back to the action default `flavor: latest=auto`. Because the tag list includes `type=ref,event=tag`, any tag push whose version isn't pre-release semver auto-generates a `latest` tag — meaning `latest` can be won by whichever branch releases most recently (e.g. a noble release), not just resolute (`main`) releases.

## Fix

Add `flavor: latest=false` to disable the *automatic* `latest` tag. The existing explicit `type=raw,value=latest` entry in the `tags:` list is kept, so `latest` is still produced on every `main` (resolute) release — it's just no longer producible by the auto-tagging heuristic, so another branch's release can't steal it. The `resolute` and `26.04` tags are unchanged.

## Follow-up (not done in this PR)

Live `latest` in GHCR still points at the noble image from today's release; it will self-correct on the next resolute (main) release, or an admin can re-point it manually. This PR only stops future noble releases from stealing it.

## Companion PR

A matching PR targeting `noble` adds `flavor: latest=false` to that branch's metadata-action step too, since noble's tag list currently still includes `type=ref,event=tag` and would otherwise still auto-generate `latest` on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY3Gv2rbRV3RqePVXTCbRq)_